### PR TITLE
Apply patch: ed25519-soft-token-csr-fix.patch

### DIFF
--- a/modules/cesecore-common/src/org/cesecore/keybind/impl/OcspKeyBinding.java
+++ b/modules/cesecore-common/src/org/cesecore/keybind/impl/OcspKeyBinding.java
@@ -48,6 +48,7 @@ import org.cesecore.util.ui.DynamicUiProperty;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateParsingException;
@@ -58,46 +59,46 @@ import java.util.Map;
 
 /**
  * Holder of "external" (e.g. non-CA signing key) OCSP InternalKeyBinding properties.
- * 
+ *
  * @version $Id$
  */
 public class OcspKeyBinding extends InternalKeyBindingBase {
-  
+
     private static final long serialVersionUID = 1L;
     private static final Logger log = Logger.getLogger(OcspKeyBinding.class);
 
     public enum ResponderIdType {
         KEYHASH(2, "KeyHash"), NAME(1, "Name");
-        
+
         private final int numericValue;
         private final String label;
         private static Map<Integer, ResponderIdType> numericValueLookupMap = new HashMap<>();
         private static Map<String, ResponderIdType> labelLookupMap = new HashMap<>();
-        
+
         static {
             for (ResponderIdType responderIdType : ResponderIdType.values()) {
                 numericValueLookupMap.put(responderIdType.getNumericValue(), responderIdType);
                 labelLookupMap.put(responderIdType.getLabel(), responderIdType);
             }
         }
-        
+
         private ResponderIdType(int numericValue, String label) {
             this.numericValue = numericValue;
             this.label = label;
         }
-        
+
         public int getNumericValue() {
             return numericValue;
         }
-        
+
         public String getLabel() {
             return label;
         }
-        
+
         public static ResponderIdType getFromNumericValue(int numericValue) {
             return numericValueLookupMap.get(numericValue);
         }
-        
+
         public static ResponderIdType getFromLabel(final String label) {
             return labelLookupMap.get(label);
         }
@@ -115,10 +116,10 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
     public static final String PROPERTY_UNTIL_NEXT_UPDATE = "untilNextUpdate";
     public static final String PROPERTY_MAX_AGE = "maxAge";
     public static final String PROPERTY_ENABLE_NONCE = "enableNonce";
-    public static final String PROPERTY_OMIT_REASON_CODE_WHEN_REVOCATION_REASON_UNSPECIFIED = "omitreasoncodewhenrevocationreasonunspecified"; 
+    public static final String PROPERTY_OMIT_REASON_CODE_WHEN_REVOCATION_REASON_UNSPECIFIED = "omitreasoncodewhenrevocationreasonunspecified";
     public static final String PROPERTY_USE_ISSUER_NOTBEFORE_AS_ARCHIVE_CUTOFF = "useIssuerNotBeforeAsArchiveCutoff";
     public static final String PROPERTY_RETENTION_PERIOD = "retentionPeriod";
-    
+
     {
         addProperty(new DynamicUiProperty<>(PROPERTY_NON_EXISTING_GOOD, Boolean.FALSE));
         addProperty(new DynamicUiProperty<>(PROPERTY_NON_EXISTING_REVOKED, Boolean.FALSE));
@@ -135,12 +136,12 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
 
     }
 
-    
+
     @Override
     public String getImplementationAlias() {
         return IMPLEMENTATION_ALIAS;
     }
-    
+
     @Override
     public float getLatestVersion() {
         return serialVersionUID;
@@ -150,7 +151,7 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
     protected void upgrade(float latestVersion, float currentVersion) {
         // Nothing to do
     }
-    
+
     @Override
     public void assertCertificateCompatability(final Certificate certificate, final AvailableExtendedKeyUsagesConfiguration ekuConfig) throws CertificateImportException {
         assertCertificateCompatabilityInternal(certificate, ekuConfig);
@@ -217,7 +218,7 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
     public void setMaxAge(long maxAge) {
         setProperty(PROPERTY_MAX_AGE, maxAge);
     }
-    
+
     /** @return true if NONCE's are to be used in replies */
     public boolean isNonceEnabled() {
         if(getProperty(PROPERTY_ENABLE_NONCE) == null) {
@@ -225,13 +226,13 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
         }
         return (Boolean) getProperty(PROPERTY_ENABLE_NONCE).getValue();
     }
-    /** 
+    /**
      * @param enabled as true of NONCE's are to be included in replies
      *  */
     public void setNonceEnabled(boolean enabled) {
         setProperty(PROPERTY_ENABLE_NONCE, enabled);
     }
-    
+
     /** @return true if the revocation reason to be omitted if specified */
     public boolean isOmitReasonCodeEnabled() {
         if(getProperty(PROPERTY_OMIT_REASON_CODE_WHEN_REVOCATION_REASON_UNSPECIFIED) == null) {
@@ -243,7 +244,7 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
     public void setOmitReasonCodeEnabled(boolean enabled) {
         setProperty(PROPERTY_OMIT_REASON_CODE_WHEN_REVOCATION_REASON_UNSPECIFIED, enabled);
     }
-    
+
     /** Helper method to check if the OCSP Archive CutOff extension is enabled. Used by Configdump */
     public boolean isOcspArchiveCutOffExtensionEnabled() {
         return getOcspExtensions().stream().anyMatch(enabledOcspExtension -> OCSPObjectIdentifiers.id_pkix_ocsp_archive_cutoff.getId().equals(enabledOcspExtension));
@@ -251,11 +252,11 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
 
     /**
      * Get the retention period being enforced by the CA. The date obtained by subtracting this
-     * retention interval value from the producedAt time in a response is defined as the 
+     * retention interval value from the producedAt time in a response is defined as the
      * certificate's "archive cutoff" date.
-     * 
+     *
      * <p>If nothing is specified for this OCSP key binding, the default value of 1 year is used.
-     * 
+     *
      * @return the retention period for archive cutoff.
      */
     public SimpleTime getRetentionPeriod() {
@@ -265,7 +266,7 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
 
     /**
      * Set the retention period being enforced by the CA. See also {@link #getRetentionPeriod()}.
-     * 
+     *
      * @param retentionPeriod the new retention period to use for archive cutoff.
      */
     public void setRetentionPeriod(final SimpleTime retentionPeriod) {
@@ -276,12 +277,12 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
      * Get a boolean indicating whether the notBefore date of the issuer of the certificate being queried for,
      * should be used as archive cutoff date in OCSP responses, when the archiveCutoff extension is enabled
      * (instead of deriving the archive cutoff date from the producedAt time of the OCSP response).
-     * 
+     *
      * <p>This setting should be enabled to conform with ETSI EN 319 411-2, CSS-6.3.10-08.
-     * 
+     *
      * <p>If nothing is specified for this OCSP key binding, the default value of false is returned
      * (do not use the issuer's notBefore date as archive cutoff date).
-     *  
+     *
      * @return true if the responder is using ETSI compliant archive cutoff dates.
      */
     public boolean getUseIssuerNotBeforeAsArchiveCutoff() {
@@ -292,7 +293,7 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
      * Set a boolean indicating whether the notBefore date of the issuer of the certificate being queried for,
      * should be used as archive cutoff date in OCSP responses, when the archiveCutoff extension is enabled.
      * See also {@link #getUseIssuerNotBeforeAsArchiveCutoff()}.
-     * 
+     *
      * @param useIssuerNotBeforeAsArchiveCutoff true to enable this setting, false otherwise.
      */
     public void setUseIssuerNotBeforeAsArchiveCutoff(final boolean useIssuerNotBeforeAsArchiveCutoff) {
@@ -368,27 +369,22 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
     @Override
     public byte[] generateCsrForNextKeyPairEd25519(final String providerName, final PublicKey publicKey, final String signatureAlgorithm,
             final X500Name subjectDn, String alias) throws IOException, NoSuchAlgorithmException, OperatorCreationException {
-                System.out.println("Reached OcspKeyBinding generateCsrForNextKeyPair");
+        log.debug("Generating Ed25519 CSR for OCSP key binding with provider: " + providerName);
 
         final KeyPurposeId[] ocspKeyPurposeId = new KeyPurposeId[] { KeyPurposeId.id_kp_OCSPSigning };
         final SubjectKeyIdentifier subjectKeyIdentifier = new JcaX509ExtensionUtils()
                 .createSubjectKeyIdentifier(publicKey);
 
-        
+        // Build OCSP-specific extensions
         KeyUsage keyUsage = new KeyUsage(KeyUsage.digitalSignature);
         boolean isCritical = true;
 
         ASN1OctetString keyUsageOctetString = new DEROctetString(keyUsage.getEncoded(ASN1Encoding.DER));
-
         Extension keyUsageExtension = new Extension(Extension.keyUsage, isCritical, keyUsageOctetString);
-
-        //Extensions extensions = new Extensions(new Extension[]{keyUsageExtension});
-
 
         Extension subjectKeyIdentifierExtension = new Extension(
             Extension.subjectKeyIdentifier,
             false, // Non-critical
-            // Use the provided object's key identifier bytes
             new DEROctetString(subjectKeyIdentifier.getKeyIdentifier())
         );
 
@@ -414,18 +410,126 @@ public class OcspKeyBinding extends InternalKeyBindingBase {
             ocspNocheckExtension
         });
 
-
         Attribute extensionAttribute = new Attribute(
             PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
-            new DERSet(extensions) 
+            new DERSet(extensions)
         );
         ASN1Set attributesSet = new DERSet(extensionAttribute);
 
+        // Detect provider type to determine signing approach
+        final boolean isUtimacoHsm = providerName != null &&
+            (providerName.contains("libcs2_pkcs11.so") || providerName.contains("libcs_pkcs11_R2.so"));
 
-        return CertTools
-                .genPKCS10CertificationRequest(signatureAlgorithm, subjectDn, publicKey, attributesSet, alias, providerName)
-                .getEncoded();
+        if (isUtimacoHsm) {
+            // For Utimaco HSM: Use the custom Ed25519.sign() method via CertTools
+            log.debug("Using Utimaco HSM Ed25519 signing path");
+            return CertTools
+                    .genPKCS10CertificationRequest(signatureAlgorithm, subjectDn, publicKey, attributesSet, alias, providerName)
+                    .getEncoded();
+        } else {
+            // For soft tokens (BouncyCastle): This path requires private key which we don't have
+            // This is a limitation of the current method signature - the private key needs to be passed
+            log.error("Soft token Ed25519 CSR generation requires private key, but current method signature does not support it.");
+            throw new OperatorCreationException("Ed25519 CSR generation for soft tokens requires private key access. " +
+                    "Please use the overloaded method that accepts a PrivateKey parameter.");
+        }
+    }
 
-        
+    /**
+     * Generate CSR for Ed25519 key pair with explicit private key support for soft tokens.
+     * This method supports both HSM (Utimaco) and soft token (BouncyCastle) providers.
+     *
+     * @param providerName the crypto provider name
+     * @param publicKey the public key
+     * @param privateKey the private key (can be null for HSM)
+     * @param signatureAlgorithm the signature algorithm
+     * @param subjectDn the subject DN
+     * @param alias the key alias (used for HSM signing)
+     * @return the encoded CSR bytes
+     * @throws IOException if encoding fails
+     * @throws NoSuchAlgorithmException if algorithm is not supported
+     * @throws OperatorCreationException if content signer creation fails
+     */
+    public byte[] generateCsrForNextKeyPairEd25519(final String providerName, final PublicKey publicKey, final PrivateKey privateKey,
+            final String signatureAlgorithm, final X500Name subjectDn, String alias)
+            throws IOException, NoSuchAlgorithmException, OperatorCreationException {
+        log.debug("Generating Ed25519 CSR for OCSP key binding with provider: " + providerName);
+
+        final KeyPurposeId[] ocspKeyPurposeId = new KeyPurposeId[] { KeyPurposeId.id_kp_OCSPSigning };
+        final SubjectKeyIdentifier subjectKeyIdentifier = new JcaX509ExtensionUtils()
+                .createSubjectKeyIdentifier(publicKey);
+
+        // Build OCSP-specific extensions
+        KeyUsage keyUsage = new KeyUsage(KeyUsage.digitalSignature);
+        boolean isCritical = true;
+
+        ASN1OctetString keyUsageOctetString = new DEROctetString(keyUsage.getEncoded(ASN1Encoding.DER));
+        Extension keyUsageExtension = new Extension(Extension.keyUsage, isCritical, keyUsageOctetString);
+
+        Extension subjectKeyIdentifierExtension = new Extension(
+            Extension.subjectKeyIdentifier,
+            false, // Non-critical
+            new DEROctetString(subjectKeyIdentifier.getKeyIdentifier())
+        );
+
+        ExtendedKeyUsage extendedKeyUsage = new ExtendedKeyUsage(ocspKeyPurposeId);
+        Extension extendedKeyUsageExtension = new Extension(
+            Extension.extendedKeyUsage,
+            false, // Non-critical
+            new DEROctetString(extendedKeyUsage.getEncoded(ASN1Encoding.DER))
+        );
+
+        ASN1ObjectIdentifier ocspNoCheckOid = OCSPObjectIdentifiers.id_pkix_ocsp_nocheck;
+        DERNull ocspNoCheckValue = DERNull.INSTANCE;
+        Extension ocspNocheckExtension = new Extension(
+            ocspNoCheckOid,
+            false, // Non-critical
+            new DEROctetString(ocspNoCheckValue.getEncoded(ASN1Encoding.DER))
+        );
+
+        Extensions extensions = new Extensions(new Extension[]{
+            keyUsageExtension,
+            subjectKeyIdentifierExtension,
+            extendedKeyUsageExtension,
+            ocspNocheckExtension
+        });
+
+        Attribute extensionAttribute = new Attribute(
+            PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+            new DERSet(extensions)
+        );
+        ASN1Set attributesSet = new DERSet(extensionAttribute);
+
+        // Detect provider type to determine signing approach
+        final boolean isUtimacoHsm = providerName != null &&
+            (providerName.contains("libcs2_pkcs11.so") || providerName.contains("libcs_pkcs11_R2.so"));
+
+        if (isUtimacoHsm) {
+            // For Utimaco HSM: Use the custom Ed25519.sign() method via CertTools
+            log.debug("Using Utimaco HSM Ed25519 signing path");
+            return CertTools
+                    .genPKCS10CertificationRequest(signatureAlgorithm, subjectDn, publicKey, attributesSet, alias, providerName)
+                    .getEncoded();
+        } else {
+            // For soft tokens (BouncyCastle): Use standard BouncyCastle ContentSigner
+            log.debug("Using BouncyCastle soft token Ed25519 signing path");
+
+            if (privateKey == null) {
+                throw new OperatorCreationException("Private key is required for soft token Ed25519 CSR generation");
+            }
+
+            // Use standard BouncyCastle PKCS10 builder with BouncyCastle provider
+            final String bcProvider = "BC"; // BouncyCastle provider
+            final PKCS10CertificationRequestBuilder csrBuilder = new JcaPKCS10CertificationRequestBuilder(subjectDn, publicKey)
+                    .addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions);
+
+            // Create content signer with BouncyCastle provider
+            final ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm)
+                    .setProvider(bcProvider)
+                    .build(privateKey);
+
+            final PKCS10CertificationRequest csr = csrBuilder.build(contentSigner);
+            return csr.getEncoded();
+        }
     }
 }

--- a/modules/cesecore-common/src/org/cesecore/keys/util/Ed25519.java
+++ b/modules/cesecore-common/src/org/cesecore/keys/util/Ed25519.java
@@ -56,7 +56,7 @@ public class Ed25519 {
 
     /**
      * Generates a keypair using C jacknji11 implementation
-     * 
+     *
      * @param keyAlias    key alias
      * @param providerName Name of the provider
      * @return X509Certificate
@@ -67,18 +67,18 @@ public class Ed25519 {
     public X509Certificate generateEd25519(final String keyAlias, String providerName) throws InvalidKeyException, CertificateException, IOException{
 
         HsmInformation hsmInfo = hsmInfoCache.get(providerName);
-        
+
         LongRef pubKey = new LongRef();
         LongRef privKey = new LongRef();
         generateKeyPairEd25519(hsmInfo, pubKey, privKey, keyAlias);
-        
+
         return generateSelfCertificate(pubKey, privKey, keyAlias, hsmInfo);
     }
 
 
     /**
      * Generates a public-key / private-key Ed25519 pair, creates new key objects.
-     * 
+     *
      * @param hsmInfo    HSM info cache
      * @param publicKey  handle of new public key
      * @param privateKey handle of new private key
@@ -120,8 +120,8 @@ public class Ed25519 {
                             new CKA(CKA.ID, keyalias.getBytes()),
             };
 
-        
-        
+
+
             C.GenerateKeyPair(sessionRef.value(), new CKM(CKM.ECDSA_KEY_PAIR_GEN), pubTempl, privTempl, publicKey, privateKey);
         } catch (CKRException rv) {
             hsmInfo.CloseSession(sessionRef);
@@ -129,16 +129,16 @@ public class Ed25519 {
         }finally{
             if(sessionRef != null){
                 hsmInfo.releaseSession(sessionRef);
-            }  
+            }
             log.info("Generated KeyPair with alias: " + keyalias);
         }
     }
 
     /**
      * Generates the EJBCA self certificate so keys can be recognized.
-     * 
+     *
      * @param pubKey Public key of the alias
-     * @param privKey Private key of the alias 
+     * @param privKey Private key of the alias
      * @param keyAlias Key Alias
      * @param hsmInfo Cache info
      * @return X509Certificate
@@ -151,7 +151,7 @@ public class Ed25519 {
         try {
             sessionRef = hsmInfo.getSession();
 
-        
+
             final long currentTime = new Date().getTime();
             final Date firstDate = new Date(currentTime - 24 * 60 * 60 * 1000);
             final Date lastDate = new Date(currentTime + (long) (30 * 24 * 60 * 60 * 365) * 1000);
@@ -172,7 +172,7 @@ public class Ed25519 {
                 new CKA(CKA.EC_POINT),
                 new CKA(CKA.EC_PARAMS)
             };
-            
+
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
             // allocate memory and call again
             for (int i = 0; i < templ.length; i++){
@@ -181,9 +181,9 @@ public class Ed25519 {
 
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
-            
+
             final CKA ecPoint = templ[0];
-            
+
             certGen.setIssuer(issuer);
             certGen.setSubject(issuer);
             certGen.setStartDate(new Time(firstDate));
@@ -204,7 +204,7 @@ public class Ed25519 {
             byte[] certBlock = bOut.toByteArray();
             byte[] signature;
 
-            
+
             // since the algorythm is Ed25519 there's no need to create a digest.
             C.SignInit(sessionRef.value(), new CKM(CKM.ECDSA), privKey.value());
 
@@ -242,7 +242,7 @@ public class Ed25519 {
                 new CKA(CKA.VALUE, cert.getEncoded())
             };
 
-            
+
             C.CreateObject(sessionRef.value(), certTemplate, certRef);
 
             updateKeypairCache(keyAlias, hsmInfo);
@@ -260,15 +260,15 @@ public class Ed25519 {
         }
 
     }
-    
+
 
     /**
      * Signs data with C jacknji11 hsm implementation
-     * 
+     *
      * @param alias Key Alias
      * @param data data to sign
      * @param providerName Name of provider
-     * @return byte[] signed data 
+     * @return byte[] signed data
      */
 
     public byte[] sign(String alias, byte[] data, String providerName){
@@ -276,8 +276,18 @@ public class Ed25519 {
         HsmInformation hsmInfo = null;
         try {
             hsmInfo = hsmInfoCache.get(providerName);
+
+            // Defensive null check - this method only works with HSM providers
+            if (hsmInfo == null) {
+                throw new IllegalStateException(
+                    "HSM provider not initialized. The sign() method only works with HSM providers (e.g., Utimaco). " +
+                    "Provider '" + providerName + "' is not an HSM provider or has not been initialized via updateHsmInfoCache(). " +
+                    "Please ensure the HSM is properly configured and initialized before calling this method."
+                );
+            }
+
             sessionRef = hsmInfo.getSession();
-            
+
             if(!hsmInfo.KeyPairCache.containsKey(alias)){
                 updateKeypairCache(alias, hsmInfo);
             }
@@ -307,7 +317,7 @@ public class Ed25519 {
 
     /**
      * Removes a keypair from HSM and Cache
-     * 
+     *
      * @param alias Key Alias
      * @param providerName Name of provider
      */
@@ -318,7 +328,7 @@ public class Ed25519 {
         try {
             hsmInfo = hsmInfoCache.get(providerName);
             sessionRef = hsmInfo.getSession();
-        
+
 
             if(!hsmInfo.KeyPairCache.containsKey(alias)){
                 updateKeypairCache(alias,hsmInfo);
@@ -347,12 +357,12 @@ public class Ed25519 {
 
     /**
      * Initializes and fills Token Cache as well as update password on change
-     * 
+     *
      * @param providerName Name of token provider
      * @param tokenName Name of the token
      * @param slotLabel slot of the token
      * @param authCode authentication code
-     * @param sharedLibrary library path 
+     * @param sharedLibrary library path
      * @return Cache instance
      */
     public static synchronized HsmInformation updateHsmInfoCache(String providerName, String tokenName, String slotLabel, String authCode, String sharedLibrary){
@@ -363,7 +373,7 @@ public class Ed25519 {
                 hsmInf.setAuthCode(authCode);
 
                 LongRef sessionRef = new LongRef();
-        
+
                 C.NATIVE = new org.pkcs11.jacknji11.jna.JNA(sharedLibrary);
                 C.Initialize();
 
@@ -379,9 +389,9 @@ public class Ed25519 {
 
             return hsmInf;
         }else{
-        
+
             LongRef sessionRef = new LongRef();
-        
+
             C.NATIVE = new org.pkcs11.jacknji11.jna.JNA(sharedLibrary);
             C.Initialize();
 
@@ -396,10 +406,10 @@ public class Ed25519 {
 
     /**
      * Changes name of token in Cache
-     * 
+     *
      * @param providerName Name of current provider
      * @param oldTokenName Old Name
-     * @param newTokenName New Name 
+     * @param newTokenName New Name
      */
     public static synchronized void updateCachedName(String providerName, String oldTokenName, String newTokenName) {
         HsmInformation hsmInf = hsmInfoCache.get(providerName);
@@ -411,7 +421,7 @@ public class Ed25519 {
 
     /**
      * Removes a token from Cache
-     * 
+     *
      * @param providerName Name of provider
      * @param tokenName Name of the token
      */
@@ -429,7 +439,7 @@ public class Ed25519 {
 
     /**
      * Updates the Cache with keypairs
-     * 
+     *
      * @param alias Key Alias
      * @param hsmCache Cache
      */
@@ -446,7 +456,7 @@ public class Ed25519 {
             }
         }
     }
-        
+
 
     /**
      * Gets the LongRef of a Private Key through it's alias.
@@ -456,7 +466,7 @@ public class Ed25519 {
      */
     public static LongRef getPrivateKeyRef(String alias, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
@@ -489,7 +499,7 @@ public class Ed25519 {
      */
     public static LongRef getCertificateRef(String alias, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
@@ -522,14 +532,14 @@ public class Ed25519 {
      */
     public static String getID(LongRef pubKey, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
             CKA[] templ = new CKA[]{
                 new CKA(CKA.ID),
             };
-            
+
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
             // allocate memory and call again
             for (int i = 0; i < templ.length; i++){
@@ -559,7 +569,7 @@ public class Ed25519 {
      */
     public static LongRef getPublicKeyRef(String alias, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
@@ -593,14 +603,14 @@ public class Ed25519 {
      */
     public static String getAlgo(LongRef pubKey, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
             CKA[] templ = new CKA[]{
                 new CKA(CKA.KEY_TYPE),
             };
-            
+
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
             // allocate memory and call again
             for (int i = 0; i < templ.length; i++){
@@ -609,7 +619,7 @@ public class Ed25519 {
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
             final CKA algo = templ[0];
-            
+
             return CKK.L2S(algo.getValueLong());
 
         }catch (CKRException rv) {
@@ -631,14 +641,14 @@ public class Ed25519 {
      */
     public static String getECDSAparams(LongRef pubKey, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
             CKA[] templ = new CKA[]{
                 new CKA(CKA.EC_PARAMS),
             };
-            
+
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
             // allocate memory and call again
             for (int i = 0; i < templ.length; i++){
@@ -648,7 +658,7 @@ public class Ed25519 {
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
             final CKA params = templ[0];
-            
+
             return params.getValueStr();
         }catch (CKRException rv) {
             hsmInfo.CloseSession(sessionRef);
@@ -669,7 +679,7 @@ public class Ed25519 {
      */
     public static BigInteger getRsaModulus(LongRef pubKey, HsmInformation hsmInfo){
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
@@ -686,7 +696,7 @@ public class Ed25519 {
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
             final CKA mod = templ[0];
-            
+
             return mod.getValueBigInt();
         }catch (CKRException rv) {
             hsmInfo.CloseSession(sessionRef);
@@ -708,7 +718,7 @@ public class Ed25519 {
     public static BigInteger getRsaPublicExponent(LongRef pubKey, HsmInformation hsmInfo){
 
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
@@ -726,7 +736,7 @@ public class Ed25519 {
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
             final CKA exp = templ[0];
-            
+
             return exp.getValueBigInt();
 
         }catch (CKRException rv) {
@@ -749,14 +759,14 @@ public class Ed25519 {
     public static Long getRsaModulusBits(LongRef pubKey, HsmInformation hsmInfo){
 
         LongRef sessionRef = null;
-        
+
         try{
             sessionRef = hsmInfo.getSession();
 
             CKA[] templ = new CKA[]{
                 new CKA(CKA.MODULUS_BITS),
             };
-            
+
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
             // allocate memory and call again
@@ -767,7 +777,7 @@ public class Ed25519 {
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
 
             final CKA bits = templ[0];
-            
+
             return bits.getValueLong();
 
         }catch (CKRException rv) {
@@ -805,7 +815,7 @@ public class Ed25519 {
         private final LinkedList<LongRef> activeSessions = new LinkedList<>();
         private String sharedLibrary;
         private HashMap<String,KeyPairInfo> KeyPairCache;
-        
+
 
         public HsmInformation (String authcode, String slot, String tokenName, LongRef sessionRef, String sharedLibrary){
             this.authcode = authcode;
@@ -972,7 +982,7 @@ public class Ed25519 {
 
             long[] result = new long[(int) count];
             System.arraycopy(found, 0, result, 0, result.length);
-            
+
             C.FindObjectsFinal(sessionRef.value());
 
             for(long ref : result){
@@ -1006,12 +1016,12 @@ public class Ed25519 {
                 LongRef certificate = getCertificateRef(alias, hsmInfo);
 
                 if(algo.equals("EC")){
-                    
+
                     String ecParams = getECDSAparams(publicKey, hsmInfo);
-                    
+
                     if(ecParams.equals("edwards25519") && certificate.value == (long) 0 ){
                         String id = getID(publicKey, hsmInfo);
-                        
+
                         try {
                             generateSelfCertificateFix(publicKey, privateKey, alias, hsmInfo , id);
                         } catch (InvalidKeyException | CertificateException | IOException e) {
@@ -1022,7 +1032,7 @@ public class Ed25519 {
                 }else if(algo.equals("RSA") && certificate.value == (long) 0 ){
 
                     String id = getID(publicKey, hsmInfo);
-                        
+
                     try {
                         generateSelfCertificateFixRsa(publicKey, privateKey, alias, hsmInfo , id);
                     } catch (InvalidKeyException | CertificateException | IOException e) {
@@ -1045,7 +1055,7 @@ public class Ed25519 {
     /**
      * Copy of generateSelfCertificate above but used only for fixing certificates so it can have same IDs
      * @param pubKey Public key of the alias
-     * @param privKey Private key of the alias 
+     * @param privKey Private key of the alias
      * @param keyAlias Key Alias
      * @param hsmInfo Cache info
      * @param id public key ID
@@ -1079,7 +1089,7 @@ public class Ed25519 {
                 new CKA(CKA.EC_POINT),
                 new CKA(CKA.EC_PARAMS)
             };
-            
+
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
             // allocate memory and call again
             for (int i = 0; i < templ.length; i++){
@@ -1088,7 +1098,7 @@ public class Ed25519 {
             //templ[0].pValue = new byte[(int) templ[0].ulValueLen];
             C.GetAttributeValue(sessionRef.value(), pubKey.value(), templ);
             final CKA ecPoint = templ[0];
-            
+
             certGen.setIssuer(issuer);
             certGen.setSubject(issuer);
             certGen.setStartDate(new Time(firstDate));
@@ -1162,7 +1172,7 @@ public class Ed25519 {
         /**
      * Copy of generateSelfCertificate above but used only for fixing certificates so it can have same IDs. RSA version
      * @param pubKey Public key of the alias
-     * @param privKey Private key of the alias 
+     * @param privKey Private key of the alias
      * @param keyAlias Key Alias
      * @param hsmInfo Cache info
      * @param id public key ID
@@ -1199,7 +1209,7 @@ public class Ed25519 {
 
             RSAPublicKey pk = new RSAPublicKey(n, e);
 
-            
+
             certGen.setIssuer(issuer);
             certGen.setSubject(issuer);
             certGen.setStartDate(new Time(firstDate));

--- a/modules/cesecore-ejb/src/org/cesecore/keybind/InternalKeyBindingMgmtSessionBean.java
+++ b/modules/cesecore-ejb/src/org/cesecore/keybind/InternalKeyBindingMgmtSessionBean.java
@@ -622,10 +622,18 @@ public class InternalKeyBindingMgmtSessionBean implements InternalKeyBindingMgmt
         final String signatureAlgorithm = internalKeyBinding.getSignatureAlgorithm();
         final CryptoToken cryptoToken = cryptoTokenManagementSession.getCryptoToken(cryptoTokenId);
 
+        // Determine if we should use HSM-specific Ed25519 path (Utimaco only) or standard path
+        final String providerName = cryptoToken.getSignProviderName();
+        final boolean isEd25519 = publicKey != null && "Ed25519".equals(publicKey.getAlgorithm());
+        final boolean isUtimacoHsm = providerName != null &&
+            (providerName.contains("libcs2_pkcs11.so") || providerName.contains("libcs_pkcs11_R2.so"));
+
         PrivateKey privateKey = null;
-        if(publicKey != null && (publicKey.getAlgorithm() == "Ed25519" )){
+        if(isEd25519 && isUtimacoHsm){
+            // For Utimaco HSM Ed25519, we use the custom Ed25519 signing path (no private key needed)
             privateKey = null;
         }else{
+            // For soft tokens and all other cases, get the private key
             privateKey = cryptoToken.getPrivateKey(keyPairAlias);
         }
 
@@ -660,12 +668,19 @@ public class InternalKeyBindingMgmtSessionBean implements InternalKeyBindingMgmt
             }
         }
         try {
-            if(publicKey != null && (publicKey.getAlgorithm() == "Ed25519" )){
-                return internalKeyBinding.generateCsrForNextKeyPairEd25519(cryptoToken.getSignProviderName(), publicKey,
+            if(isEd25519 && isUtimacoHsm){
+                // For Utimaco HSM Ed25519, use the HSM-specific path
+                return internalKeyBinding.generateCsrForNextKeyPairEd25519(providerName, publicKey,
+                    signatureAlgorithm, x500Name, keyPairAlias);
+            }
+            else if(isEd25519 && internalKeyBinding instanceof OcspKeyBinding){
+                // For soft token Ed25519 with OcspKeyBinding, use the overloaded method with private key
+                return ((OcspKeyBinding) internalKeyBinding).generateCsrForNextKeyPairEd25519(providerName, publicKey, privateKey,
                     signatureAlgorithm, x500Name, keyPairAlias);
             }
             else{
-                return internalKeyBinding.generateCsrForNextKeyPair(cryptoToken.getSignProviderName(), new KeyPair(publicKey, privateKey),
+                // For all other cases, use standard CSR generation
+                return internalKeyBinding.generateCsrForNextKeyPair(providerName, new KeyPair(publicKey, privateKey),
                         signatureAlgorithm, x500Name);
             }
         } catch (OperatorCreationException | IOException | NoSuchAlgorithmException e) {


### PR DESCRIPTION
# Fix: Ed25519 CSR Generation for Soft CryptoTokens

Fixes #19 

## Problem Summary

CSR generation (`gencsr`) failed for Ed25519 OCSP key bindings using **soft cryptotokens** with a `NullPointerException`.

### Error
```
java.lang.NullPointerException
    at org.cesecore.keys.util.Ed25519.sign(Ed25519.java:279)
    at org.cesecore.util.CertTools.genPKCS10CertificationRequest(CertTools.java:4559)
    at org.cesecore.keybind.impl.OcspKeyBinding.generateCsrForNextKeyPairEd25519(OcspKeyBinding.java:426)
```

## Root Cause

Commit `2b9545cee2` (Luis Pereira, April 4, 2025) introduced Ed25519 CSR generation support but incorrectly routed **all** Ed25519 keys (both HSM and soft tokens) through HSM-only code paths.

The `Ed25519.sign()` method:
- Only works with HSM providers (Utimaco via PKCS#11/jacknji11)
- Expects provider names like `"utimaco-libcs2_pkcs11.so"`
- Fails with `NullPointerException` when given soft token provider `"BC"` (BouncyCastle)

This violated the Utimaco-only restriction established in commit `df46f8a7b1` (May 11, 2023).

## Solution

Implemented proper provider detection to distinguish between Utimaco HSM and soft tokens, routing each to appropriate CSR generation logic.

### Files Modified

1. **InternalKeyBindingMgmtSessionBean.java** - Fixed routing logic
2. **OcspKeyBinding.java** - Added soft token CSR generation support
3. **Ed25519.java** - Added defensive null check with clear error message

## Changes Detail

### 1. InternalKeyBindingMgmtSessionBean.java (lines 625-690)

**Before:**
```java
if(publicKey != null && (publicKey.getAlgorithm() == "Ed25519" )){
    return internalKeyBinding.generateCsrForNextKeyPairEd25519(...);
}
```

**After:**
```java
// Detect provider type
final String providerName = cryptoToken.getSignProviderName();
final boolean isEd25519 = publicKey != null && "Ed25519".equals(publicKey.getAlgorithm());
final boolean isUtimacoHsm = providerName != null &&
    (providerName.contains("libcs2_pkcs11.so") || providerName.contains("libcs_pkcs11_R2.so"));

if(isEd25519 && isUtimacoHsm){
    // Utimaco HSM path
    return internalKeyBinding.generateCsrForNextKeyPairEd25519(...);
}
else if(isEd25519 && internalKeyBinding instanceof OcspKeyBinding){
    // Soft token Ed25519 path with private key
    return ((OcspKeyBinding) internalKeyBinding).generateCsrForNextKeyPairEd25519(..., privateKey, ...);
}
else{
    // Standard path for all other cases
    return internalKeyBinding.generateCsrForNextKeyPair(...);
}
```

**Key improvements:**
- Fixed string comparison bug (`==` → `.equals()`)
- Added provider type detection
- Route to HSM path only for Utimaco
- Route to new soft token path for BC provider

### 2. OcspKeyBinding.java (lines 369-454)

**Added overloaded method** accepting `PrivateKey` parameter:
```java
public byte[] generateCsrForNextKeyPairEd25519(
    final String providerName,
    final PublicKey publicKey,
    final PrivateKey privateKey,  // <-- NEW
    final String signatureAlgorithm,
    final X500Name subjectDn,
    String alias)
```

**Logic:**
- Detects provider type (Utimaco HSM vs BouncyCastle)
- **For Utimaco HSM**: Uses existing `CertTools.genPKCS10CertificationRequest()` with `Ed25519.sign()`
- **For soft tokens**: Uses standard BouncyCastle `JcaContentSignerBuilder` with private key
- Both paths include proper OCSP extensions (KeyUsage, ExtendedKeyUsage, SubjectKeyIdentifier, OCSP NoCheck)

### 3. Ed25519.java (lines 280-287)

Added defensive null check:
```java
hsmInfo = hsmInfoCache.get(providerName);

if (hsmInfo == null) {
    throw new IllegalStateException(
        "HSM provider not initialized. The sign() method only works with HSM providers (e.g., Utimaco). " +
        "Provider '" + providerName + "' is not an HSM provider or has not been initialized..."
    );
}
```

Provides clear error message if routing logic fails.

## Testing

Test with soft cryptotoken:
```bash
/opt/ejbca/bin/ejbca.sh keybind gencsr --name ocsp-soft-PREPROD-Scania-CN-ECU-Auth-CA -f /tmp/test.csr
```

**Expected result**: CSR generated successfully using BouncyCastle provider.

Test with Utimaco HSM:
```bash
/opt/ejbca/bin/ejbca.sh keybind gencsr --name ocsp-hsm-utimaco-test -f /tmp/test.csr
```

**Expected result**: CSR generated successfully using Utimaco HSM signing.

## Historical Context

- **May 11, 2023** (`df46f8a7b1`): Ed25519 custom jacknji11 flow restricted to Utimaco only
- **April 4, 2025** (`2b9545cee2`): Ed25519 OCSP CSR generation added, but forgot Utimaco-only restriction → **BUG INTRODUCED**
- **Current fix**: Restores Utimaco-only restriction for CSR generation

## Impact

- **Soft tokens**: Ed25519 OCSP key bindings can now generate CSRs
- **HSM tokens**: Existing Utimaco HSM functionality preserved
- **Backward compatible**: No breaking changes to existing workflows

## Branch

`fix/ed25519-soft-token-csr-generation`

